### PR TITLE
Fix `.aws/config` file profile syntax

### DIFF
--- a/templates/aws_config.j2
+++ b/templates/aws_config.j2
@@ -1,6 +1,6 @@
 {% if item.profiles is defined %}
 {% for profile in item.profiles %}
-[{{ profile.name }}]
+[profile {{ profile.name }}]
 output = {{ profile.output | default('json') }}
 region = {{ profile.region | default('') }}
 {% endfor %}


### PR DESCRIPTION
#### Because:

* Unlike `.aws/credentials`, the `.aws/config` file expects a 'profile '
  prefix in the profile definitions, ref:
  http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-config-files