### PR TITLE
Avoid setting config and creds values to empty

### DIFF
--- a/templates/aws_config.j2
+++ b/templates/aws_config.j2
@@ -1,11 +1,20 @@
 {% if item.profiles is defined %}
 {% for profile in item.profiles %}
 [profile {{ profile.name }}]
-output = {{ profile.output | default('json') }}
-region = {{ profile.region | default('') }}
+{% if profile.output | default(false) %}
+output = {{ profile.output }}
+{% endif %}
+{% if profile.region | default(false) %}
+region = {{ profile.region }}
+{% endif %}
+
 {% endfor %}
 {% else %}
 [default]
-output = {{ item.output | default('json') }}
-region = {{ item.region | default('') }}
+{% if item.output | default(false) %}
+output = {{ item.output }}
+{% endif %}
+{% if item.region | default(false) %}
+region = {{ item.region }}
+{% endif %}
 {% endif %}

--- a/templates/aws_credentials.j2
+++ b/templates/aws_credentials.j2
@@ -1,11 +1,20 @@
 {% if item.profiles is defined %}
 {% for profile in item.profiles %}
 [{{ profile.name }}]
-aws_access_key_id = {{ profile.access_key_id | default('') }}
-aws_secret_access_key = {{ profile.secret_access_key | default('') }}
+{% if profile.access_key_id | default(false) %}
+aws_access_key_id = {{ profile.access_key_id }}
+{% endif %}
+{% if profile.secret_access_key | default(false) %}
+aws_secret_access_key = {{ profile.secret_access_key }}
+{% endif %}
+
 {% endfor %}
 {% else %}
 [default]
-aws_access_key_id = {{ item.access_key_id | default('') }}
-aws_secret_access_key = {{ item.secret_access_key | default('') }}
+{% if item.access_key_id | default(false) %}
+aws_access_key_id = {{ item.access_key_id }}
+{% endif %}
+{% if item.secret_access_key | default(false) %}
+aws_secret_access_key = {{ item.secret_access_key }}
+{% endif %}
 {% endif %}


### PR DESCRIPTION
#### Because:

* AWS CLI treats settings in the config and credentials that are set
  without a value e.g. `output = ` as set, but empty.
* This behaviour is different to when the settings are omitted entirely.
* `aws configure` omits any unset values, so it makes sense for the role
  to do the same.

#### This change:

* Checks if config and credentials values are set before outputting them
  to ensure we don't set any setting to null/empty.