### PR TITLE
Add variable to specify pip package

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,12 @@ Role Variables
 --------------
 
 ```yml
+# Name of the 'pip' package to install
+awscli_pip_package: python-pip
+
+# Version of 'awscli' to install
 awscli_version: 1.11.73
 ```
-The version of `awscli` to install.
 
 ```yml
 awscli_users: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 # defaults file for awscli
 
+awscli_pip_package: python-pip
 awscli_version: 1.11.73
 
 awscli_users: []

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -6,5 +6,5 @@
   become: yes
 
 - name: Install python-pip via apt.
-  apt: "name=python-pip state=installed"
+  apt: "name={{ awscli_pip_package }} state=installed"
   become: yes

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -2,5 +2,5 @@
 # ref: https://github.com/dbcli/awscli/blob/v1.8.1/README.md
 
 - name: Install python-pip via yum.
-  yum: "name=python-pip state=installed"
+  yum: "name={{ awscli_pip_package }} state=installed"
   become: yes


### PR DESCRIPTION
It's pretty common to be running python3 these days, which means some users will need to install the `python3-pip` package instead of the `python-pip` package. 