### PR TITLE
Fixed failure checking for installed state on python-pip - changed to…

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -6,5 +6,5 @@
   become: yes
 
 - name: Install python-pip via apt.
-  apt: "name={{ awscli_pip_package }} state=installed"
+  apt: "name={{ awscli_pip_package }} state=present"
   become: yes


### PR DESCRIPTION
… present

Ansible 2.9, Ubuntu 18.04

Following diagnostic on play:
TASK [tommarshall.awscli : Install python-pip via apt.] ************************
fatal: [default]: FAILED! => {"changed": false, "msg": "value of state must be one of: absent, build-dep, fixed, latest, present, got: installed"}

Changed the state check to "present" which fixes the issue. 